### PR TITLE
Ajout d'un endpoint POST /demo avec réception, validation et affichage des données utilisateur JSON

### DIFF
--- a/src/Controller/DemoController.php
+++ b/src/Controller/DemoController.php
@@ -2,26 +2,46 @@
 
 namespace App\Controller;
 
+use App\Service\UserDataService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\HttpFoundation\Request;
+use JsonException;
+
+/**
+ * Contrôleur de démonstration pour le traitement des données utilisateur.
+ * 
+ * Endpoint POST /demo
+ * Attend un JSON avec la structure suivante :
+ * {
+ *     "name": "string",
+ *     "age": "integer",
+ *     "email": "string",
+ *     "phone": "string"
+ * }
+ */
 final class DemoController extends AbstractController
 {
-    #[Route('/demo', name: 'app_demo')]
+    public function __construct(
+        private readonly UserDataService $userDataService
+    ) {
+    }
+
+    #[Route('/demo', name: 'app_demo', methods: ['POST'])]
     public function index(Request $request): Response
     {
-        // 1. Récupérer les données soumises par un POST API au format JSON
+        try {
+            $userData = $this->userDataService->createFromJson($request->getContent());
 
-        $data = $request->getContent();
-
-        // 2. Convertir les données JSON en objet PHP
-
-        $data = json_decode($data);
-
-        return $this->render('demo/index.html.twig', [
-            'controller_name' => 'DemoController',
-            'data' => $data,
-        ]);
+            return $this->render('demo/index.html.twig', [
+                'controller_name' => 'DemoController',
+                'userData' => $userData,
+            ]);
+        } catch (JsonException $e) {
+            return $this->json(['error' => 'Invalid JSON format'], Response::HTTP_BAD_REQUEST);
+        } catch (\InvalidArgumentException $e) {
+            return $this->json(['error' => $e->getMessage()], Response::HTTP_BAD_REQUEST);
+        }
     }
 }

--- a/src/Controller/DemoController.php
+++ b/src/Controller/DemoController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\HttpFoundation\Request;
+final class DemoController extends AbstractController
+{
+    #[Route('/demo', name: 'app_demo')]
+    public function index(Request $request): Response
+    {
+        // 1. Récupérer les données soumises par un POST API au format JSON
+
+        $data = $request->getContent();
+
+        // 2. Convertir les données JSON en objet PHP
+
+        $data = json_decode($data);
+
+        return $this->render('demo/index.html.twig', [
+            'controller_name' => 'DemoController',
+            'data' => $data,
+        ]);
+    }
+}

--- a/src/Controller/DemoController.php
+++ b/src/Controller/DemoController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller;
 
 use App\Service\UserDataService;
@@ -18,7 +20,7 @@ use JsonException;
  *     "name": "string",
  *     "age": "integer",
  *     "email": "string",
- *     "phone": "string"
+ *     "phone": "string" (format international: +33612345678)
  * }
  */
 final class DemoController extends AbstractController

--- a/src/DTO/UserData.php
+++ b/src/DTO/UserData.php
@@ -22,7 +22,10 @@ final class UserData
         private readonly string $email,
 
         #[Assert\NotBlank]
-        #[Assert\Regex(pattern: '/^\+?[0-9]{10,}$/')]
+        #[Assert\Regex(
+            pattern: '/^\+[1-9][0-9]{10,14}$/',
+            message: 'Le numéro de téléphone doit être au format international (ex: +33612345678)'
+        )]
         private readonly string $phone,
     ) {
     }

--- a/src/DTO/UserData.php
+++ b/src/DTO/UserData.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class UserData
+{
+    public function __construct(
+        #[Assert\NotBlank]
+        #[Assert\Length(min: 2, max: 255)]
+        private readonly string $name,
+
+        #[Assert\NotBlank]
+        #[Assert\Range(min: 0, max: 150)]
+        private readonly int $age,
+
+        #[Assert\NotBlank]
+        #[Assert\Email]
+        private readonly string $email,
+
+        #[Assert\NotBlank]
+        #[Assert\Regex(pattern: '/^\+?[0-9]{10,}$/')]
+        private readonly string $phone,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getAge(): int
+    {
+        return $this->age;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function getPhone(): string
+    {
+        return $this->phone;
+    }
+} 

--- a/src/Service/UserDataService.php
+++ b/src/Service/UserDataService.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\DTO\UserData;
+use JsonException;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final class UserDataService
+{
+    public function __construct(
+        private readonly ValidatorInterface $validator
+    ) {
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function createFromJson(string $jsonData): UserData
+    {
+        $data = json_decode($jsonData, true, 512, JSON_THROW_ON_ERROR);
+
+        if (!isset($data['name'], $data['age'], $data['email'], $data['phone'])) {
+            throw new \InvalidArgumentException('Missing required fields in JSON data');
+        }
+
+        $userData = new UserData(
+            name: $data['name'],
+            age: (int) $data['age'],
+            email: $data['email'],
+            phone: $data['phone']
+        );
+
+        $violations = $this->validator->validate($userData);
+        
+        if (count($violations) > 0) {
+            throw new \InvalidArgumentException((string) $violations);
+        }
+
+        return $userData;
+    }
+} 

--- a/templates/demo/index.html.twig
+++ b/templates/demo/index.html.twig
@@ -1,0 +1,16 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Hello DemoController!{% endblock %}
+
+{% block body %}
+
+    <h1>Hello {{ controller_name }}! ✅</h1>
+
+    <h2>Data</h2>
+
+    <p>{{ data.name }}</p>
+    <p>{{ data.age }}</p>
+    <p>{{ data.email }}</p>
+    <p>{{ data.phone }}</p>
+    
+{% endblock %}

--- a/templates/demo/index.html.twig
+++ b/templates/demo/index.html.twig
@@ -3,14 +3,25 @@
 {% block title %}Hello DemoController!{% endblock %}
 
 {% block body %}
-
     <h1>Hello {{ controller_name }}! ✅</h1>
 
-    <h2>Data</h2>
+    <h2>Données utilisateur</h2>
 
-    <p>{{ data.name }}</p>
-    <p>{{ data.age }}</p>
-    <p>{{ data.email }}</p>
-    <p>{{ data.phone }}</p>
-    
+    {% if userData is defined %}
+        <dl>
+            <dt>Nom</dt>
+            <dd>{{ userData.name }}</dd>
+
+            <dt>Âge</dt>
+            <dd>{{ userData.age }}</dd>
+
+            <dt>Email</dt>
+            <dd>{{ userData.email }}</dd>
+
+            <dt>Téléphone</dt>
+            <dd>{{ userData.phone }}</dd>
+        </dl>
+    {% else %}
+        <p class="alert alert-warning">Aucune donnée utilisateur disponible.</p>
+    {% endif %}
 {% endblock %}

--- a/tests/Controller/DemoControllerTest.php
+++ b/tests/Controller/DemoControllerTest.php
@@ -17,7 +17,7 @@ class DemoControllerTest extends WebTestCase
             'name' => 'John Doe',
             'age' => 30,
             'email' => 'john@example.com',
-            'phone' => '0123456789'
+            'phone' => '+33612345678'
         ];
 
         $client->request(
@@ -68,5 +68,30 @@ class DemoControllerTest extends WebTestCase
         $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
         $response = json_decode($client->getResponse()->getContent(), true);
         $this->assertStringContainsString('Missing required fields', $response['error']);
+    }
+
+    public function testIndexWithInvalidPhoneFormat(): void
+    {
+        $client = static::createClient();
+
+        $data = [
+            'name' => 'John Doe',
+            'age' => 30,
+            'email' => 'john@example.com',
+            'phone' => '0612345678' // Format local non autorisé
+        ];
+
+        $client->request(
+            'POST',
+            '/demo',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode($data)
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertStringContainsString('format international', $response['error']);
     }
 } 

--- a/tests/Controller/DemoControllerTest.php
+++ b/tests/Controller/DemoControllerTest.php
@@ -1,3 +1,5 @@
+<?php
+
 declare(strict_types=1);
 
 namespace App\Tests\Controller;

--- a/tests/Controller/DemoControllerTest.php
+++ b/tests/Controller/DemoControllerTest.php
@@ -1,0 +1,70 @@
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class DemoControllerTest extends WebTestCase
+{
+    public function testIndexWithValidData(): void
+    {
+        $client = static::createClient();
+
+        $data = [
+            'name' => 'John Doe',
+            'age' => 30,
+            'email' => 'john@example.com',
+            'phone' => '0123456789'
+        ];
+
+        $client->request(
+            'POST',
+            '/demo',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode($data)
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('h1', 'Hello DemoController!');
+        $this->assertSelectorTextContains('dd', 'John Doe');
+    }
+
+    public function testIndexWithInvalidJson(): void
+    {
+        $client = static::createClient();
+
+        $client->request(
+            'POST',
+            '/demo',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            'invalid json'
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertEquals('Invalid JSON format', $response['error']);
+    }
+
+    public function testIndexWithMissingData(): void
+    {
+        $client = static::createClient();
+
+        $client->request(
+            'POST',
+            '/demo',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode(['name' => 'John Doe'])
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertStringContainsString('Missing required fields', $response['error']);
+    }
+} 

--- a/tests/Service/UserDataServiceTest.php
+++ b/tests/Service/UserDataServiceTest.php
@@ -27,7 +27,7 @@ class UserDataServiceTest extends TestCase
             'name' => 'John Doe',
             'age' => 30,
             'email' => 'john@example.com',
-            'phone' => '0123456789'
+            'phone' => '+33612345678'
         ]);
 
         $userData = $this->userDataService->createFromJson($jsonData);
@@ -36,7 +36,7 @@ class UserDataServiceTest extends TestCase
         $this->assertEquals('John Doe', $userData->getName());
         $this->assertEquals(30, $userData->getAge());
         $this->assertEquals('john@example.com', $userData->getEmail());
-        $this->assertEquals('0123456789', $userData->getPhone());
+        $this->assertEquals('+33612345678', $userData->getPhone());
     }
 
     public function testCreateFromJsonWithInvalidJson(): void
@@ -49,5 +49,19 @@ class UserDataServiceTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->userDataService->createFromJson('{"name": "John Doe"}');
+    }
+
+    public function testCreateFromJsonWithInvalidPhoneFormat(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        
+        $jsonData = json_encode([
+            'name' => 'John Doe',
+            'age' => 30,
+            'email' => 'john@example.com',
+            'phone' => '0612345678' // Format local non autorisé
+        ]);
+
+        $this->userDataService->createFromJson($jsonData);
     }
 } 

--- a/tests/Service/UserDataServiceTest.php
+++ b/tests/Service/UserDataServiceTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\DTO\UserData;
+use App\Service\UserDataService;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Validation;
+
+class UserDataServiceTest extends TestCase
+{
+    private UserDataService $userDataService;
+
+    protected function setUp(): void
+    {
+        $validator = Validation::createValidatorBuilder()
+            ->getValidator();
+
+        $this->userDataService = new UserDataService($validator);
+    }
+
+    public function testCreateFromJsonWithValidData(): void
+    {
+        $jsonData = json_encode([
+            'name' => 'John Doe',
+            'age' => 30,
+            'email' => 'john@example.com',
+            'phone' => '0123456789'
+        ]);
+
+        $userData = $this->userDataService->createFromJson($jsonData);
+
+        $this->assertInstanceOf(UserData::class, $userData);
+        $this->assertEquals('John Doe', $userData->getName());
+        $this->assertEquals(30, $userData->getAge());
+        $this->assertEquals('john@example.com', $userData->getEmail());
+        $this->assertEquals('0123456789', $userData->getPhone());
+    }
+
+    public function testCreateFromJsonWithInvalidJson(): void
+    {
+        $this->expectException(\JsonException::class);
+        $this->userDataService->createFromJson('invalid json');
+    }
+
+    public function testCreateFromJsonWithMissingData(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->userDataService->createFromJson('{"name": "John Doe"}');
+    }
+} 


### PR DESCRIPTION
Cette PR introduit un nouveau contrôleur Symfony 'DemoController' exposant un endpoint POST '/demo' qui reçoit des données utilisateur au format JSON. Les données attendues contiennent les champs 'name', 'age', 'email' et 'phone'. Le contenu JSON est décodé et transformé en objet UserData via le service UserDataService, qui effectue également la validation des données selon des contraintes définies. En cas d'erreur de format JSON ou de validation, une réponse HTTP 400 est retournée avec un message d'erreur explicite. Si les données sont valides, elles sont transmises à une vue Twig pour affichage simple. La PR comprend aussi des tests unitaires pour le service de gestion des données utilisateur et des tests fonctionnels pour le contrôleur afin de garantir le comportement correct de l'endpoint et la gestion des erreurs.